### PR TITLE
Clarify License discrepancy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Jameson Lopp
+Copyright (c) 2019 Exodus Movement, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
       "\\.js$": "babel-jest"
     }
   },
-  "author": "Exodus",
-  "license": "ISC",
+  "contributors": [
+    "Jameson Lopp",
+    "Exodus Movement, Inc."
+  ],
+  "license": "MIT",
   "publishConfig": {
     "access": "restricted"
   },


### PR DESCRIPTION
The license in the `package.json` didn't agree with the `LICENSE` file; clarified this to the correct legal standing.