### PR TITLE
Adapted to bs58check V4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bs58check": "^2.1.2"
+    "bs58check": "^4.0.0"
   },
   "devDependencies": {
-    "jest": "^26.2.2"
+    "jest": "^29.7"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const bs58check = require('bs58check')
+const bs58check = require('bs58check').default
 
 /*
   This script uses version bytes as described in SLIP-132


### PR DESCRIPTION
Interface with bs58check 4.0.0 has changed and require statement in CommonJS modules needs an additional .default property: `const bs58check = require('bs58check').default`.

Note that import statement in ESM modules doesn't need it: `import bs58check from 'bs58check'`.